### PR TITLE
Attached Window (Unfocused but On-top) whenever Active Window is osu!

### DIFF
--- a/osu!cat.py
+++ b/osu!cat.py
@@ -57,10 +57,8 @@ def ontop():
         if root.state() == 'iconic':
             root.deiconify()
         root.attributes('-topmost', True)
-        root.update()
     else:
         root.attributes('-topmost', False)
-        root.update()
 
 
 def find_distance(cx, cy, px, py):  # Calculates the distance from the cursor position to a point
@@ -87,7 +85,7 @@ def find_frame(cx, cy, f):
 
 print('Bongo Cat Live Cam v1.0.0')
 print('----------------------------------------------------------------------------------------------------------------------')
-print('Disclaimer: There is a high probability you will experience som bugs or that the program will now work at all.\n'
+print('Disclaimer: There is a high probability you will experience some bugs or that the program will now work at all.\n'
       'This program will also most likely not work on resolutions where the height is bigger than the width, it will most\n'
       'likely use much of your cpu and there is no support for custom ingame resolutions. You have been warned.')
 print('----------------------------------------------------------------------------------------------------------------------')
@@ -112,6 +110,19 @@ while True:
     else:
         print('Invalid input')
 
+print('(Attach window to osu? This will keep the window open but unfocused so you can see it while playing.)')
+print('(Type 0 for yes and 1 for no)')
+while True:
+    attach_ans = input('Attach: ')
+    if attach_ans == '0':
+        attach = True
+        break
+    elif attach_ans == '1':
+        attach = False
+        break
+    else:
+        print('Invalid input')
+
 print('All done! To reconfigure, just close and relaunch the application')
 
 open_img = PIL.Image.open("cat/{0}/Hand A.png".format(cursor_device))
@@ -129,7 +140,8 @@ f = 'A'
 last_hit = 0
 LOOP = True
 while LOOP:
-    ontop()
+    if attach:
+        ontop()
 
     k1_p = is_pressed(k1)
     k2_p = is_pressed(k2)

--- a/osu!cat.py
+++ b/osu!cat.py
@@ -17,7 +17,6 @@ root = Tk()
 root.resizable(width=False, height=False)
 root.title('osu!cat v1.0.0')
 root.protocol('WM_DELETE_WINDOW', close_window)
-root.attributes('-topmost', True)
 
 screen_x = root.winfo_screenwidth()
 screen_y = root.winfo_screenheight()

--- a/osu!cat.py
+++ b/osu!cat.py
@@ -1,6 +1,8 @@
 from tkinter import Tk, Label
 import PIL.ImageTk
 import PIL.Image
+from win32gui import GetWindowText, GetForegroundWindow
+
 from keyboard import is_pressed
 from win32gui import GetCursorPos
 from math import sqrt
@@ -11,11 +13,11 @@ def close_window():
     global LOOP
     LOOP = False
 
-
 root = Tk()
 root.resizable(width=False, height=False)
 root.title('osu!cat v1.0.0')
 root.protocol('WM_DELETE_WINDOW', close_window)
+root.attributes('-topmost', True)
 
 screen_x = root.winfo_screenwidth()
 screen_y = root.winfo_screenheight()
@@ -48,6 +50,17 @@ frame_points = {'A': (x_1, y_1),
                 'IB': (ix_2, iy_1),
                 'IC': (ix_1, iy_2),
                 'ID': (ix_2, iy_2)}
+
+def ontop():
+    active_window_name = GetWindowText(GetForegroundWindow())
+    if 'osu!' in active_window_name and 'osu!cat' not in active_window_name:
+        if root.state() == 'iconic':
+            root.deiconify()
+        root.attributes('-topmost', True)
+        root.update()
+    else:
+        root.attributes('-topmost', False)
+        root.update()
 
 
 def find_distance(cx, cy, px, py):  # Calculates the distance from the cursor position to a point
@@ -116,6 +129,8 @@ f = 'A'
 last_hit = 0
 LOOP = True
 while LOOP:
+    ontop()
+
     k1_p = is_pressed(k1)
     k2_p = is_pressed(k2)
     x, y = GetCursorPos()

--- a/osu!cat.py
+++ b/osu!cat.py
@@ -2,7 +2,6 @@ from tkinter import Tk, Label
 import PIL.ImageTk
 import PIL.Image
 from win32gui import GetWindowText, GetForegroundWindow
-
 from keyboard import is_pressed
 from win32gui import GetCursorPos
 from math import sqrt


### PR DESCRIPTION
Tweaked script so that the program asks whether or not the user wants to attach the window to osu! Having osu! in focus will result in the window being brought up but not focused so the user can see both the osu! window and osu-cat window while maintaining the ability to play in osu!

In response to issue #3 