### PR TITLE
Bug and Perf fixes

### DIFF
--- a/osu!cat.py
+++ b/osu!cat.py
@@ -102,64 +102,62 @@ while True:
 
 print('All done! To reconfigure, just close and relaunch the application')
 
-open_img = PIL.Image.open("cat/{0}/Hand A.png".format(cursor_device))
-base_img = PIL.ImageTk.PhotoImage(open_img)
-hit1_img = PIL.Image.open("cat/KeyTapHand.png")
-hit2_img = PIL.Image.open("cat/KeyTapHand2.png")
+#preload all images
+hit_images = {
+    1: PIL.Image.open("cat/KeyTapHand.png"),
+    2: PIL.Image.open("cat/KeyTapHand2.png")
+}
+cursor_images = { }
+for key in frame_points.keys():
+    cursor_images[key] = PIL.Image.open("cat/{0}/Hand {1}.png".format(cursor_device, key))
 
 #l_xyf = StringVar()  # Label string for x and y cursor position + current base frame
 
-image_label = Label(root, image=base_img) # ,textvariable=l_xyf, compound=CENTER)
-image_label.image = base_img
+default_img = PIL.ImageTk.PhotoImage(cursor_images['A'])
+image_label = Label(root, image=default_img) # ,textvariable=l_xyf, compound=CENTER)
+image_label.image = default_img
 image_label.pack()
 
 f = 'A'
-last_hit = 0
+f_prev = f
+k1_p_prev = False
+k2_p_prev = False
+hit_prev = 1
 LOOP = True
 while LOOP:
+    sleep(0.005)
     k1_p = is_pressed(k1)
     k2_p = is_pressed(k2)
     x, y = GetCursorPos()
     f = find_frame(x, y, f)
+    
+    if f == f_prev and k1_p == k1_p_prev and k2_p == k2_p_prev:
+        continue
 
-    n_open_img = PIL.Image.open("cat/{0}/Hand {1}.png".format(cursor_device, f))
+    base_img = cursor_images[f]
 
     if k1_p or k2_p:
 
-        final_hit_img = hit1_img
-
-        if last_hit == 0:
-
-            if k1_p:
-
-                final_hit_img = hit1_img
-                last_hit = 1
-
-            elif k2_p:
-
-                final_hit_img = hit2_img
-                last_hit = 0
-
-        elif last_hit == 1:
-
-            if k2_p:
-
-                final_hit_img = hit2_img
-                last_hit = 0
-
-            elif k1_p:
-
-                final_hit_img = hit1_img
-                last_hit = 1
-
-        test_var = PIL.Image.alpha_composite(n_open_img, final_hit_img)
+        if (k1_p and not k1_p_prev) or (not k2_p and k2_p_prev):
+            final_hit = 1
+        elif (k2_p and not k2_p_prev) or (not k1_p and k1_p_prev):
+            final_hit = 2
+        else:
+            final_hit = hit_prev
+    
+        hit_prev = final_hit
+        final_hit_img = hit_images[final_hit]
+        test_var = PIL.Image.alpha_composite(base_img, final_hit_img)
         n_base_img = PIL.ImageTk.PhotoImage(test_var)
     else:
-        n_base_img = PIL.ImageTk.PhotoImage(n_open_img)
+        n_base_img = PIL.ImageTk.PhotoImage(base_img)
 
+    f_prev = f
+    k1_p_prev = k1_p
+    k2_p_prev = k2_p
+    
     image_label.configure(image=n_base_img)
     image_label.image = n_base_img
 
     #l_xyf.set('x: ' + str(x) + ' ' + 'y: ' + str(y) + ' ' + 'frame: ' + f)  # Updates x, y and frame values
     root.update()
-    sleep(0.005)

--- a/osu!cat.py
+++ b/osu!cat.py
@@ -122,7 +122,7 @@ f = 'A'
 f_prev = f
 k1_p_prev = False
 k2_p_prev = False
-hit_prev = 1
+last_hit = 1
 LOOP = True
 while LOOP:
     sleep(0.005)
@@ -143,9 +143,9 @@ while LOOP:
         elif (k2_p and not k2_p_prev) or (not k1_p and k1_p_prev):
             final_hit = 2
         else:
-            final_hit = hit_prev
+            final_hit = last_hit
     
-        hit_prev = final_hit
+        last_hit = final_hit
         final_hit_img = hit_images[final_hit]
         test_var = PIL.Image.alpha_composite(base_img, final_hit_img)
         n_base_img = PIL.ImageTk.PhotoImage(test_var)

--- a/osu!cat.py
+++ b/osu!cat.py
@@ -4,6 +4,7 @@ import PIL.Image
 from keyboard import is_pressed
 from win32gui import GetCursorPos
 from math import sqrt
+from time import sleep
 
 
 def close_window():
@@ -161,3 +162,4 @@ while LOOP:
 
     #l_xyf.set('x: ' + str(x) + ' ' + 'y: ' + str(y) + ' ' + 'frame: ' + f)  # Updates x, y and frame values
     root.update()
+    sleep(0.005)


### PR DESCRIPTION
Addressing performance concerns from issue #8:
- Preload all images to avoid accessing disk every frame.
- Add short sleep to avoid busy-looping
- Check current state to avoid re-compositing when nothing has changed

Addressing bug #11:
- Updated keypress logic. The image now matches the most-recently-pressed key which is still pressed (For example: if you hold both keys, it stays on the most recent. if you hold one key and tap the other, it switches between the two, matching the taps)